### PR TITLE
Fix Strategy payment type properties

### DIFF
--- a/Behavioral/Strategy/Payment.API/Domain/Strategies/Cash.cs
+++ b/Behavioral/Strategy/Payment.API/Domain/Strategies/Cash.cs
@@ -1,10 +1,11 @@
+using System;
 using Strategy.Payment.Contracts;
 
 namespace Strategy.Payment.Strategies;
 
 internal class Cash : IPaymentStrategy
 {
-   public EPaymentType Type { get ; }
+   public EPaymentType Type { get; private set; }
 
    public Cash()
    {

--- a/Behavioral/Strategy/Payment.API/Domain/Strategies/CreditCard.cs
+++ b/Behavioral/Strategy/Payment.API/Domain/Strategies/CreditCard.cs
@@ -1,10 +1,11 @@
+using System;
 using Strategy.Payment.Contracts;
 
 namespace Strategy.Payment.Strategies;
 
 internal class CreditCard : IPaymentStrategy
 {
-   public EPaymentType Type { get; }
+   public EPaymentType Type { get; private set; }
 
    public CreditCard()
    {


### PR DESCRIPTION
## Summary
- add `System` namespace usage to strategy implementations
- allow private setters on `Type` property in `Cash` and `CreditCard`
- verify build

## Testing
- `dotnet build DesignPatterns.sln`

------
https://chatgpt.com/codex/tasks/task_e_684966cf63148331bda0007a8996a822