### PR TITLE
Add xUnit tests for PaymentResolver

### DIFF
--- a/Behavioral/Strategy/Payment.API/Properties/AssemblyInfo.cs
+++ b/Behavioral/Strategy/Payment.API/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Payment.Tests")]

--- a/Behavioral/Strategy/Payment.Tests/GlobalUsings.cs
+++ b/Behavioral/Strategy/Payment.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Behavioral/Strategy/Payment.Tests/Payment.Tests.csproj
+++ b/Behavioral/Strategy/Payment.Tests/Payment.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Payment.API/Payment.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Behavioral/Strategy/Payment.Tests/PaymentResolverTests.cs
+++ b/Behavioral/Strategy/Payment.Tests/PaymentResolverTests.cs
@@ -1,0 +1,31 @@
+using Strategy.Payment;
+using Strategy.Payment.Strategies;
+using Strategy.Payment.Contracts;
+using Xunit;
+
+namespace Payment.Tests;
+
+public class PaymentResolverTests
+{
+    [Fact]
+    public void Resolve_ReturnsCashStrategy_WhenTypeIsCash()
+    {
+        IPaymentStrategy[] strategies = { new Cash(), new CreditCard() };
+        var resolver = new PaymentResolver(strategies);
+
+        var result = resolver.resolve(EPaymentType.Cash);
+
+        Assert.IsType<Cash>(result);
+    }
+
+    [Fact]
+    public void Resolve_ReturnsCreditCardStrategy_WhenTypeIsCreditCard()
+    {
+        IPaymentStrategy[] strategies = { new Cash(), new CreditCard() };
+        var resolver = new PaymentResolver(strategies);
+
+        var result = resolver.resolve(EPaymentType.CreditCard);
+
+        Assert.IsType<CreditCard>(result);
+    }
+}

--- a/DesignPatterns.sln
+++ b/DesignPatterns.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Strategy", "Strategy", "{22
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Payment.API", "Behavioral\Strategy\Payment.API\Payment.API.csproj", "{F4DA5B3C-DC2B-42A3-89AD-01655DD17E60}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Payment.Tests", "Behavioral\Strategy\Payment.Tests\Payment.Tests.csproj", "{4D24208C-E059-4052-B1DB-8D46D6BF0498}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{F4DA5B3C-DC2B-42A3-89AD-01655DD17E60}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4DA5B3C-DC2B-42A3-89AD-01655DD17E60}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4DA5B3C-DC2B-42A3-89AD-01655DD17E60}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4D24208C-E059-4052-B1DB-8D46D6BF0498}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4D24208C-E059-4052-B1DB-8D46D6BF0498}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4D24208C-E059-4052-B1DB-8D46D6BF0498}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4D24208C-E059-4052-B1DB-8D46D6BF0498}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -30,6 +36,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{221CCF84-868B-4D89-A43E-CDEF337CEFA4} = {0B92A082-CD4A-47AF-AD4F-2DFC513C3C03}
 		{F4DA5B3C-DC2B-42A3-89AD-01655DD17E60} = {221CCF84-868B-4D89-A43E-CDEF337CEFA4}
+		{4D24208C-E059-4052-B1DB-8D46D6BF0498} = {221CCF84-868B-4D89-A43E-CDEF337CEFA4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E50B9FA1-1C2C-4777-A4E7-C586E2BAFBA0}


### PR DESCRIPTION
## Summary
- add `Payment.Tests` xUnit project and reference `Payment.API`
- expose internals of `Payment.API` to tests
- test `PaymentResolver.resolve` for Cash and CreditCard cases
- update solution file to include new test project

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684966d613c08331a6ea8379b93eb9c4